### PR TITLE
openPMD-viewer: Change Hamburg affiliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ the work provided in those for our format handling.
 
 ### Data Processing and Visualization
 
-- [openPMD-viewer](https://github.com/openPMD/openPMD-viewer) (LBNL, DESY)
+- [openPMD-viewer](https://github.com/openPMD/openPMD-viewer) (LBNL, CFEL Hamburg University)
   - domain: high level python api and interactive IPython notebook GUI
   - [repository](https://github.com/openPMD/openPMD-viewer) (BSD-3-Clause-LBNL)
   - maintainer: R Lehe @RemiLehe et al.


### PR DESCRIPTION
To be consistent with our affiliation for FBPIC I change the information for openPMD-viewer accordingly. 