### PR TITLE
Add UPIC-Emma to the list of codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ the work provided in those for our format handling.
 
 - UPIC-Emma (UCLA, USA)
   - domain: 2-1/2D electromagnetic particle-in-cell code
-  - [repository](https://github.com/UCLA-Plasma-Simulation-Group/upic-emma-2.0)
+  - [repository](https://github.com/UCLA-Plasma-Simulation-Group/upic-emma-2.0) (UCLA-NC)
   - maintainer: F Tsung @tsung1029
   - original author: V Decyk
   - status: implemented
@@ -133,7 +133,7 @@ Please check the individual repositories and feel free to contribute.
 
 - [Fortran openPMD writer](https://github.com/UCLA-Plasma-Simulation-Group/Fortran-OpenPMD-File-Writers) (UCLA, USA)
   - domain: Fortran 2003 HDF5 File Writers in openPMD Standard
-  - [repository](https://github.com/UCLA-Plasma-Simulation-Group/Fortran-OpenPMD-File-Writers)
+  - [repository](https://github.com/UCLA-Plasma-Simulation-Group/Fortran-OpenPMD-File-Writers) (UCLA-NC)
   - maintainer: Weiming An @caozigao
   - status: openPMD 1.0 implemented
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ the work provided in those for our format handling.
   - original author: A Grund @Flamefire
   - status: implemented (base standard for X-ray laser & density profiles)
 
+- UPIC-Emma (UCLA, USA)
+  - domain: 2-1/2D electromagnetic particle-in-cell code
+  - [repository](https://github.com/UCLA-Plasma-Simulation-Group/upic-emma-2.0)
+  - maintainer: F Tsung @tsung1029
+  - original author: V Decyk
+  - status: implemented
+
 ### Data Processing and Visualization
 
 - [openPMD-viewer](https://github.com/openPMD/openPMD-viewer) (LBNL, CFEL Hamburg University)
@@ -125,7 +132,7 @@ Please check the individual repositories and feel free to contribute.
         - 1.4.0+: full API available to fulfill the standard (read+write)
 
 - [Fortran openPMD writer](https://github.com/UCLA-Plasma-Simulation-Group/Fortran-OpenPMD-File-Writers) (UCLA, USA)
-  - domain: Fortran 2003 HDF5 File Writers in openPMD Standard 
+  - domain: Fortran 2003 HDF5 File Writers in openPMD Standard
   - [repository](https://github.com/UCLA-Plasma-Simulation-Group/Fortran-OpenPMD-File-Writers)
   - maintainer: Weiming An @caozigao
   - status: openPMD 1.0 implemented


### PR DESCRIPTION
UPIC Emma recently added an openPMD writer (see [this PR](https://github.com/UCLA-Plasma-Simulation-Group/upic-emma-2.0/pull/4/files)).

Therefore, the present PR adds UPIC to the list of code.
@tsung1029 : Could you confirm that the information is correct? For the `domain`/description, I used the header of the file `upic-emma.f90`.