### PR TITLE
adding Sirepo references to the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ the work provided in those for our format handling.
   - original author: V Decyk
   - status: implemented
 
+- Sirepo/Warp PBA (RadiaSoft, USA)
+  - domain: 2-1/2D r-z electromagnetic PIC for beam-plasma and laser-plasma
+  - [repository](https://github.com/radiasoft/sirepo)
+  - [free use](https://www.sirepo.com/warppba)
+  - maintainers: P Moeller @moellep, R Nagler @robnagler, D Bruhwiler @bruhwiler
+  - original UI authors: P Moeller @moellep, R Nagler @robnagler
+  - original code authors: JL Vay @jlvay, D Grote @dpgrote
+  - status: implemented
+
+- Sirepo/Warp VND (RadiaSoft, USA)
+  - domain: 2D and 3D Cartesian electrostatic PIC with complex boundaries and dielectrics
+  - [repository](https://github.com/radiasoft/sirepo)
+  - [free use](https://www.sirepo.com/warpvnd)
+  - maintainers: P Moeller @moellep, R Nagler @robnagler, N Cook @ncook882
+  - original UI authors: P Moeller @moellep, R Nagler @robnagler, N Cook @ncook882
+  - original code authors: D Grote @dpgrote, JL Vay @jlvay
+  - status: implemented
+
 ### Data Processing and Visualization
 
 - [openPMD-viewer](https://github.com/openPMD/openPMD-viewer) (LBNL, CFEL Hamburg University)


### PR DESCRIPTION
The Sirepo/Warp PBA and Sirepo/Warp VND apps are a different case from the existing code references. I added text to reference them in a manner that seems consistent with what is being done for other software.

Here is a little more context for the record:

Warp PBA is a prototype app for laser-plasma and beam-plasma wakefield simulations.
It uses the r-z mesh with azimuthal modes.

Warp VND is an app for doing electrostatic PIC with complicated conducting boundaries and dielectrics. The VND stands for vacuum nanoelectronics. The primary problem domain that has been considered is thermionic converters.

For both Warp PBA and Warp VND, the data files are using the OpenPMD standard.