### PR TITLE
Add HiPACE++ to the list of openPMD-capable codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ the work provided in those for our format handling.
   - original code authors: D Grote @dpgrote, JL Vay @jlvay
   - status: implemented
 
+- [HiPACE++](https://hipace.readthedocs.io) (DESY, LBNL)
+  - domain: 3D GPU-capable quasi-static particle-in-cell code for plasma acceleration
+  - [repository](https://github.com/Hi-PACE/hipace) (BSD-3-Clause-LBNL)
+  - maintainers: M Thevenet @MaxThevenet, S Diederichs @SeverinDiederichs, A Huebl @ax3l et al.
+  - status: implemented
+
 ### Data Processing and Visualization
 
 - [openPMD-viewer](https://github.com/openPMD/openPMD-viewer) (LBNL, CFEL Hamburg University)


### PR DESCRIPTION
This PR proposes to add HiPACE++ to the list of codes supporting the openPMD standard in README.md.